### PR TITLE
set screenshot command nsfw channel only

### DIFF
--- a/mods/Utils.py
+++ b/mods/Utils.py
@@ -501,6 +501,7 @@ class Utils(Cog):
 
 	@commands.command(pass_context=True)
 	@commands.cooldown(1, 10)
+	@commands.is_nsfw()
 	async def screenshot(self, ctx, *, url:str):
 			try:
 				x = await self.bot.say("ok, processing")


### PR DESCRIPTION
These changes resolve the issue from #129 by adding a check if the command has been executed in an NSFW channel.
